### PR TITLE
Fix tiny logo size in sidebar

### DIFF
--- a/vatlab/styles/globals.css
+++ b/vatlab/styles/globals.css
@@ -409,7 +409,8 @@ nav {
 }
 
 .top-logo img {
-  height: 40px;
+  height: 80px;
+  width: auto;
 }
 
 footer {


### PR DESCRIPTION
## Summary

The PolicyEngine logo in the sidebar was too small (40px height). This PR increases it to 80px for better visibility.

## Changes
- Increased logo height from 40px to 80px
- Added `width: auto` to maintain aspect ratio

## Visual Impact
The logo will now be more prominent and easier to see in the sidebar.

🤖 Generated with Claude Code